### PR TITLE
Avoid alerting when using Wine-GE-Custom

### DIFF
--- a/src/views/bottle_preferences.py
+++ b/src/views/bottle_preferences.py
@@ -808,7 +808,7 @@ class PreferencesView(Adw.PreferencesPage):
                 runner=runner
             )
 
-        if "proton" in runner.lower():
+        if re.search("^(GE-)?Proton", runner):
             dialog = ProtonAlertDialog(self.window, run_task)
             dialog.show()
         else:


### PR DESCRIPTION
# Description

Having just a check of the "proton" string in the runner name is insufficient to know if this is actually a Proton runner or not since the Wine-GE release is actually called `wine-lutris-GE-Proton7-20-x86_64`.

Other quick win solution:
Ignoring if "wine" or "lutris" is found in the runner's name.

The probably better solution:
Checking inside the runner folder for some files that are only found in Proton runners.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested this regex against the current naming conventions I'm aware of with a simple Python script (I haven't tried to run a build of Bottles yet):

```
GE-Proton7-24
Proton 7.0
wine-lutris-GE-Proton7-20-x86_64
```
